### PR TITLE
added dependency lombok

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,13 @@
     <version>1.8.12</version>
 
     <dependencies>
+         <dependency>
+             <groupId>org.projectlombok</groupId>
+             <artifactId>lombok</artifactId>
+             <version>1.18.26</version>
+             <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>de.theamychan</groupId>
             <artifactId>ScoreboardAPI</artifactId>


### PR DESCRIPTION
had issues on ubuntu 22 to compile in headless with only mvn installed, adding lombok to pom, fixed the issue.